### PR TITLE
Remove warning Warning: Invalid DOM property . Did you mean ?

### DIFF
--- a/src/icons/AaShortLogo.jsx
+++ b/src/icons/AaShortLogo.jsx
@@ -5,12 +5,12 @@ export const AaShortLogo = ({ className }) => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 110.5 58" className={className}>
     <defs>
       <linearGradient id="a" x1="39.65" x2="2.88" y1="35.4" y2="14.17" gradientUnits="userSpaceOnUse">
-        <stop offset="0" stop-color="#00d9ef" />
-        <stop offset="1" stop-color="#00adc9" />
+        <stop offset="0" stopColor="#00d9ef" />
+        <stop offset="1" stopColor="#00adc9" />
       </linearGradient>
       <linearGradient id="b" x1="97.74" x2="60.92" y1="35.41" y2="14.15" gradientUnits="userSpaceOnUse">
-        <stop offset="0" stop-color="#39f" />
-        <stop offset="1" stop-color="#005ece" />
+        <stop offset="0" stopColor="#39f" />
+        <stop offset="1" stopColor="#005ece" />
       </linearGradient>
     </defs>
     <path

--- a/src/icons/AaTwoLineLogo.jsx
+++ b/src/icons/AaTwoLineLogo.jsx
@@ -13,8 +13,8 @@ export const AaTwoLineLogo = ({ className }) => (
         gradientUnits="userSpaceOnUse"
         gradientTransform="matrix(1.699706, 0, 0, 1.719523, 122.912315, 134.439713)"
       >
-        <stop offset="0" stop-color="#00d9ef"></stop>
-        <stop offset="1" stop-color="#00adc9"></stop>
+        <stop offset="0" stopColor="#00d9ef"></stop>
+        <stop offset="1" stopColor="#00adc9"></stop>
       </linearGradient>
       <linearGradient
         id="b"
@@ -25,8 +25,8 @@ export const AaTwoLineLogo = ({ className }) => (
         gradientUnits="userSpaceOnUse"
         gradientTransform="matrix(1.699706, 0, 0, 1.719523, 122.912315, 134.439713)"
       >
-        <stop offset="0" stop-color="#39f"></stop>
-        <stop offset="1" stop-color="#005ece"></stop>
+        <stop offset="0" stopColor="#39f"></stop>
+        <stop offset="1" stopColor="#005ece"></stop>
       </linearGradient>
     </defs>
     <g fill="#005ece" transform="matrix(1, 0, 0, 1, -35.124245, 223.601501)">


### PR DESCRIPTION
Warning: Invalid DOM property `stop-color`. Did you mean `stopColor`?
On default training.
I don't know if it is needed, I've just seen it and it is not shown with this change